### PR TITLE
fix(getIOSVersion): improve regex store url

### DIFF
--- a/dist/ios.js
+++ b/dist/ios.js
@@ -1,5 +1,5 @@
 export const getIOSVersion = async (storeURL = '', country = 'jp') => {
-    const appID = storeURL.match(/.+id([0-9]+)\??/);
+    const appID = storeURL.match(/.+id\(?([0-9]+)\)?\??/);
     if (!appID) {
         throw new Error('iosStoreURL is invalid.');
     }

--- a/src/ios.ts
+++ b/src/ios.ts
@@ -1,5 +1,5 @@
 export const getIOSVersion = async (storeURL = '', country = 'jp') => {
-  const appID = storeURL.match(/.+id([0-9]+)\??/);
+  const appID = storeURL.match(/.+id\(?([0-9]+)\)?\??/);
 
   if (!appID) {
     throw new Error('iosStoreURL is invalid.');


### PR DESCRIPTION
Fix a bug in getIOSVersion function where a regex blocked appIDs formatted with parenthesis.
Now, even if the appID is like this: appID(12345678), the regex will escape parenthesis to retrieve perfectly the appID.